### PR TITLE
fix: use longest-match strategy in matchVariableReferences

### DIFF
--- a/core/src/analyzer/detectVariableReferences/index.ts
+++ b/core/src/analyzer/detectVariableReferences/index.ts
@@ -1,4 +1,3 @@
-
 import type * as std from "../../law/std";
 import type { Declarations } from "../common/declarations";
 import { ____VarRef } from "../../node/el/controls/varRef";
@@ -27,51 +26,68 @@ export const matchVariableReferences = (
 ) => {
     const errors: ErrorMessage[] = [];
 
-    const found: [[offsetStart: number, offsetEnd: number], ____Declaration][] = [];
+    const candidates: [[offsetStart: number, offsetEnd: number], ____Declaration][] = [];
 
     const textRange = sentenceEnv.textRageOfEL(textEL) ?? [0, 0];
+    const rawText = textEL.text();
 
-    {
-        let ramainingText = textEL.text();
-        for (const declaration of declarations.values()) {
-            if (declaration.attr.name.length === 0) continue;
-            for (;;) {
-                const nameOffset = ramainingText.indexOf(declaration.attr.name);
-                if (nameOffset < 0) break;
+    // Collect ALL candidate matches without masking, so that longer terms
+    // that contain shorter ones are not lost due to iteration order.
+    for (const declaration of declarations.values()) {
+        if (declaration.attr.name.length === 0) continue;
+        let searchFrom = 0;
+        for (;;) {
+            const nameOffset = rawText.indexOf(declaration.attr.name, searchFrom);
+            if (nameOffset < 0) break;
 
-                const foundTextRange = {
-                    start: textRange[0] + nameOffset,
-                    end: textRange[0] + nameOffset + declaration.attr.name.length,
-                };
-                if (declaration.scope.some(scopeRange => (
-                    (
-                        (scopeRange.start.sentenceIndex < sentenceEnv.index)
-                        || (
-                            (scopeRange.start.sentenceIndex === sentenceEnv.index)
-                            && (scopeRange.start.textOffset <= foundTextRange.start)
-                        )
+            const foundTextRange = {
+                start: textRange[0] + nameOffset,
+                end: textRange[0] + nameOffset + declaration.attr.name.length,
+            };
+            if (declaration.scope.some(scopeRange => (
+                (
+                    (scopeRange.start.sentenceIndex < sentenceEnv.index)
+                    || (
+                        (scopeRange.start.sentenceIndex === sentenceEnv.index)
+                        && (scopeRange.start.textOffset <= foundTextRange.start)
                     )
-                    && (
-                        (sentenceEnv.index < scopeRange.end.sentenceIndex)
-                        || (
-                            (sentenceEnv.index === scopeRange.end.sentenceIndex)
-                            && (foundTextRange.end <= scopeRange.end.textOffset)
-                        )
+                )
+                && (
+                    (sentenceEnv.index < scopeRange.end.sentenceIndex)
+                    || (
+                        (sentenceEnv.index === scopeRange.end.sentenceIndex)
+                        && (foundTextRange.end <= scopeRange.end.textOffset)
                     )
-                ))) {
-                    found.push([[nameOffset, nameOffset + declaration.attr.name.length], declaration]);
-                    ramainingText = ramainingText.slice(0, nameOffset) + "　".repeat(declaration.attr.name.length) + ramainingText.slice(nameOffset + declaration.attr.name.length);
-                }
-
+                )
+            ))) {
+                candidates.push([[nameOffset, nameOffset + declaration.attr.name.length], declaration]);
             }
+
+            searchFrom = nameOffset + 1;
+        }
+    }
+
+    if (candidates.length === 0) return null;
+
+    // Sort by start offset ascending; for the same start, longer match first (descending end).
+    // This implements a greedy longest-match / non-overlapping selection.
+    candidates.sort(([a], [b]) => (a[0] - b[0]) || (b[1] - a[1]));
+
+    // Greedy non-overlapping selection: accept a candidate only if its
+    // start is >= the end of the last accepted match.
+    const found: [[offsetStart: number, offsetEnd: number], ____Declaration][] = [];
+    let acceptedEnd = -1;
+    for (const candidate of candidates) {
+        const [offsetRange] = candidate;
+        if (offsetRange[0] >= acceptedEnd) {
+            found.push(candidate);
+            acceptedEnd = offsetRange[1];
         }
     }
 
     if (found.length === 0) return null;
 
-    found.sort(([a], [b]) => ((a[0] - b[0]) || (a[1] - b[1]) ));
-
-    const text = textEL.text();
+    const text = rawText;
 
     const newItems: SentenceChildEL[] = [];
     const varRefs: ____VarRef[] = [];


### PR DESCRIPTION
## Problem

In `matchVariableReferences` (`core/src/analyzer/detectVariableReferences/index.ts`), when iterating over declarations and finding a match, the matched region in `ramainingText` was immediately overwritten with full-width spaces (`"　".repeat(...)`). This caused longer defined terms that **contain shorter ones** to go undetected when the shorter term happened to be processed first.

### Concrete example

Consider a law that defines all three of the following terms:

- `提供統計作成等用個人情報等` (12 chars) — the long term
- `統計作成等` (5 chars) — a sub-term contained within the long term
- `個人情報` (4 chars) — another sub-term contained within the long term

When the text `第六項に規定する提供統計作成等用個人情報等であるものを除く。` was scanned:

1. `統計作成等` (shorter) was found first → matched region masked with spaces
2. `個人情報` (shorter) was found next → matched region masked with spaces
3. `提供統計作成等用個人情報等` (longer) was searched → **not found** because the relevant characters had already been destroyed

Result: only the two short sub-terms were linked; the long term was silently dropped.

This was confirmed by reading the source directly via the GitHub connector and cross-referencing with the XML of an in-progress amendment to the Act on the Protection of Personal Information (令和7年改正個人情報保護法案).

## Fix

Instead of masking characters during collection:

1. **Collect ALL candidate matches** across all declarations from the original (unmodified) text.
2. **Sort** candidates by start offset ascending, then by length descending (longest first at the same position).
3. **Greedy non-overlapping selection**: accept a candidate only if its start offset `>=` the end of the last accepted match. This is the standard longest-match disambiguation strategy.

### Key changes in `matchVariableReferences`

| Before | After |
|---|---|
| `let ramainingText = textEL.text()` (mutable, masked in-place) | `const rawText = textEL.text()` (immutable) |
| Mask matched region with `"　".repeat(name.length)` after each hit | No masking — all candidates collected cleanly |
| `found.sort(([a],[b]) => (a[0]-b[0]) \|\| (a[1]-b[1]))` (shorter end first) | Sort by start asc, **end desc** (longer match first at same position) |
| No overlap removal | Greedy overlap removal loop added |

## Impact

This is a **pure bug fix** with no API or interface changes. All existing tests should continue to pass. The fix makes the behavior consistent regardless of the iteration order of `declarations.values()`, and correctly prefers the longest defined term at any given position.